### PR TITLE
CI/CD: Enable code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,11 @@
 name: Coverage
 on:
   push:
-    # Pattern matched against refs/tags
+    branches: [coverage]
     tags:
-      - "**" # Push events to every tag including hierarchical tags like v0.1.0/beta
-
+      - "**"
+  pull_request:
+    branches: [coverage]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
@@ -83,7 +84,7 @@ jobs:
         run: |
           ./sh_script/build.sh -r
 
-      - name: cargo build enable hashed-transcript-data
+      - name: cargo build hashed-transcript-data
         env:
           LLVM_PROFILE_FILE: build-hashed-transcript-data-%p-%m.profraw
           RUSTFLAGS: "-C instrument-coverage"
@@ -94,7 +95,29 @@ jobs:
         run: |
           ./sh_script/build.sh -r
 
-      - name: Run fuzz
+      - name: cargo build spdm-mbedtls
+        env:
+          LLVM_PROFILE_FILE: build-hashed-transcript-data-%p-%m.profraw
+          RUSTFLAGS: "-C instrument-coverage"
+          CC_x86_64_unknown_none: clang
+          AR_x86_64_unknown_none: llvm-ar
+          RUN_REQUESTER_FEATURES: "spdm-mbedtls"
+          RUN_RESPONDER_FEATURES: "spdm-mbedtls"
+        run: |
+          ./sh_script/build.sh -r
+
+      - name: cargo build mbedtls hashed-transcript-data
+        env:
+          LLVM_PROFILE_FILE: build-hashed-transcript-data-%p-%m.profraw
+          RUSTFLAGS: "-C instrument-coverage"
+          CC_x86_64_unknown_none: clang
+          AR_x86_64_unknown_none: llvm-ar
+          RUN_REQUESTER_FEATURES: "spdm-mbedtls,hashed-transcript-data,spdm-mbedtls-hashed-transcript-data"
+          RUN_RESPONDER_FEATURES: "spdm-mbedtls,hashed-transcript-data,spdm-mbedtls-hashed-transcript-data"
+        run: |
+          ./sh_script/build.sh -r
+
+      - name: Run fuzz hash-transcript-data
         env:
           FUZZ_HASH_TRANSCRIPT_DATA_FEATURE: true
         run: |
@@ -112,12 +135,23 @@ jobs:
             --branch \
             --binary-path ./target/debug/ \
             -s . \
+            -t html \
+            --ignore-not-existing \
+            -o coverage
+          grcov $(find . -name "*.profraw") \
+            --branch \
+            --binary-path ./target/debug/ \
+            -s . \
             -t lcov \
             --ignore-not-existing \
-            -o lcov.info
+            -o coverage/lcov.info
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage_data-${{ github.sha }}
+          path: coverage/
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3
         with:
-          files: ./lcov.info
-          fail_ci_if_error: true
+          files: coverage/lcov.info
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
Fix #2 

Badge requires a website to server badge image. It's not supported at this moment. The current PR generates coverage data and uploads it on github for download.

