### PR TITLE
Fix copyright/attribution in rustls files

### DIFF
--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -1,3 +1,6 @@
+// Taken from rustls <https://github.com/rustls/rustls>
+//
+// Copyright (c) 2016 Joe Birr-Pixton and rustls project contributors
 // Copyright (c) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT

--- a/codec/src/macros.rs
+++ b/codec/src/macros.rs
@@ -1,3 +1,6 @@
+// Taken from rustls <https://github.com/rustls/rustls>
+//
+// Copyright (c) 2016 Joe Birr-Pixton and rustls project contributors
 // Copyright (c) 2020 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT


### PR DESCRIPTION
Note that prior versions of this copy of the file said they were licensed under BSD 2 clause; the upstream source was never available under this license.

It's misleading that these are marked copyright Intel alone. Add further copyright lines indicating their original source.