### PR TITLE
add vendor context support for VendorDefinedStruct.

### DIFF
--- a/fuzz-target/responder/vendor_rsp/src/main.rs
+++ b/fuzz-target/responder/vendor_rsp/src/main.rs
@@ -54,8 +54,10 @@ async fn fuzz_handle_spdm_vendor_defined_request(data: Arc<Vec<u8>>) {
         .runtime_info
         .set_connection_state(SpdmConnectionState::SpdmConnectionNegotiated);
 
-    let vendor_defined_func: for<'r> fn(&'r VendorDefinedReqPayloadStruct) -> Result<_, _> =
-        |_vendor_defined_req_payload_struct| -> SpdmResult<VendorDefinedRspPayloadStruct> {
+    let vendor_defined_func: for<'r> fn(usize, &'r VendorDefinedReqPayloadStruct) -> Result<_, _> =
+        |_: usize,
+         _vendor_defined_req_payload_struct|
+         -> SpdmResult<VendorDefinedRspPayloadStruct> {
             let mut vendor_defined_res_payload_struct = VendorDefinedRspPayloadStruct {
                 rsp_length: 0,
                 vendor_defined_rsp_payload: [0; config::MAX_SPDM_MSG_SIZE - 7 - 2],
@@ -68,6 +70,7 @@ async fn fuzz_handle_spdm_vendor_defined_request(data: Arc<Vec<u8>>) {
 
     register_vendor_defined_struct(VendorDefinedStruct {
         vendor_defined_request_handler: vendor_defined_func,
+        vendor_context: 0,
     });
 
     let mut response_buffer = [0u8; spdmlib::config::MAX_SPDM_MSG_SIZE];

--- a/idekm/src/pci_ide_km_responder/pci_ide_km_rsp_dispatcher.rs
+++ b/idekm/src/pci_ide_km_responder/pci_ide_km_rsp_dispatcher.rs
@@ -16,9 +16,11 @@ use spdmlib::{
 
 pub const PCI_IDE_KM_INSTANCE: VendorDefinedStruct = VendorDefinedStruct {
     vendor_defined_request_handler: pci_ide_km_rsp_dispatcher,
+    vendor_context: 0,
 };
 
 fn pci_ide_km_rsp_dispatcher(
+    _vendor_context: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     if vendor_defined_req_payload_struct.req_length < 2 {

--- a/spdmlib/src/message/vendor.rs
+++ b/spdmlib/src/message/vendor.rs
@@ -254,14 +254,21 @@ impl SpdmCodec for SpdmVendorDefinedResponsePayload {
 #[derive(Clone, Copy)]
 pub struct VendorDefinedStruct {
     pub vendor_defined_request_handler:
-        fn(&VendorDefinedReqPayloadStruct) -> SpdmResult<VendorDefinedRspPayloadStruct>,
+        fn(usize, &VendorDefinedReqPayloadStruct) -> SpdmResult<VendorDefinedRspPayloadStruct>,
+    pub vendor_context: usize, // interpreted/managed by User
 }
 
 static VENDOR_DEFNIED: OnceCell<VendorDefinedStruct> = OnceCell::uninit();
 
 static VENDOR_DEFNIED_DEFAULT: VendorDefinedStruct = VendorDefinedStruct {
-    vendor_defined_request_handler: |_vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct|
-     -> SpdmResult<VendorDefinedRspPayloadStruct> { log::info!("not implement vendor defined struct!!!\n"); unimplemented!() },
+    vendor_defined_request_handler:
+        |_vendor_context: usize,
+         _vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct|
+         -> SpdmResult<VendorDefinedRspPayloadStruct> {
+            log::info!("not implement vendor defined struct!!!\n");
+            unimplemented!()
+        },
+    vendor_context: 0,
 };
 
 pub fn register_vendor_defined_struct(context: VendorDefinedStruct) -> bool {
@@ -272,7 +279,7 @@ pub fn vendor_defined_request_handler(
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     if let Ok(vds) = VENDOR_DEFNIED.try_get_or_init(|| VENDOR_DEFNIED_DEFAULT) {
-        (vds.vendor_defined_request_handler)(vendor_defined_req_payload_struct)
+        (vds.vendor_defined_request_handler)(vds.vendor_context, vendor_defined_req_payload_struct)
     } else {
         Err(SPDM_STATUS_INVALID_STATE_LOCAL)
     }

--- a/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
@@ -39,20 +39,25 @@ fn test_case0_handle_spdm_vendor_defined_request() {
         vendor_defined_req_payload: [0; config::MAX_SPDM_MSG_SIZE - 7 - 2],
     };
 
-    let vendor_defined_func: for<'r> fn(&'r vendor::VendorDefinedReqPayloadStruct) -> Result<_, _> =
-        |_vendor_defined_req_payload_struct| -> SpdmResult<VendorDefinedRspPayloadStruct> {
-            let mut vendor_defined_res_payload_struct = VendorDefinedRspPayloadStruct {
-                rsp_length: 0,
-                vendor_defined_rsp_payload: [0; config::MAX_SPDM_MSG_SIZE - 7 - 2],
-            };
-            vendor_defined_res_payload_struct.rsp_length = 8;
-            vendor_defined_res_payload_struct.vendor_defined_rsp_payload[0..8]
-                .clone_from_slice(b"deadbeef");
-            Ok(vendor_defined_res_payload_struct)
+    let vendor_defined_func: for<'r> fn(
+        usize,
+        &'r vendor::VendorDefinedReqPayloadStruct,
+    ) -> Result<_, _> = |_: usize,
+                         _vendor_defined_req_payload_struct|
+     -> SpdmResult<VendorDefinedRspPayloadStruct> {
+        let mut vendor_defined_res_payload_struct = VendorDefinedRspPayloadStruct {
+            rsp_length: 0,
+            vendor_defined_rsp_payload: [0; config::MAX_SPDM_MSG_SIZE - 7 - 2],
         };
+        vendor_defined_res_payload_struct.rsp_length = 8;
+        vendor_defined_res_payload_struct.vendor_defined_rsp_payload[0..8]
+            .clone_from_slice(b"deadbeef");
+        Ok(vendor_defined_res_payload_struct)
+    };
 
     register_vendor_defined_struct(VendorDefinedStruct {
         vendor_defined_request_handler: vendor_defined_func,
+        vendor_context: 0,
     });
 
     if let Ok(vendor_defined_res_payload_struct) =


### PR DESCRIPTION
Currently, spdmlib can pass only vendor defined request payload to callback, no any context/hardware information is included. This patch is to provide the flexibility for integrator to attach more information associated with vendor defined request payload to gain context.