### PR TITLE
change parameter definition to keep consistency.

### DIFF
--- a/fuzz-target/responder/vendor_rsp/src/main.rs
+++ b/fuzz-target/responder/vendor_rsp/src/main.rs
@@ -70,7 +70,7 @@ async fn fuzz_handle_spdm_vendor_defined_request(data: Arc<Vec<u8>>) {
 
     register_vendor_defined_struct(VendorDefinedStruct {
         vendor_defined_request_handler: vendor_defined_func,
-        vendor_context: 0,
+        vdm_handle: 0,
     });
 
     let mut response_buffer = [0u8; spdmlib::config::MAX_SPDM_MSG_SIZE];

--- a/idekm/src/pci_ide_km_responder/pci_ide_km_rsp_dispatcher.rs
+++ b/idekm/src/pci_ide_km_responder/pci_ide_km_rsp_dispatcher.rs
@@ -16,11 +16,11 @@ use spdmlib::{
 
 pub const PCI_IDE_KM_INSTANCE: VendorDefinedStruct = VendorDefinedStruct {
     vendor_defined_request_handler: pci_ide_km_rsp_dispatcher,
-    vendor_context: 0,
+    vdm_handle: 0,
 };
 
 pub fn pci_ide_km_rsp_dispatcher(
-    _vendor_context: usize,
+    _vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     if vendor_defined_req_payload_struct.req_length < 2 {

--- a/spdmlib/src/message/vendor.rs
+++ b/spdmlib/src/message/vendor.rs
@@ -255,20 +255,20 @@ impl SpdmCodec for SpdmVendorDefinedResponsePayload {
 pub struct VendorDefinedStruct {
     pub vendor_defined_request_handler:
         fn(usize, &VendorDefinedReqPayloadStruct) -> SpdmResult<VendorDefinedRspPayloadStruct>,
-    pub vendor_context: usize, // interpreted/managed by User
+    pub vdm_handle: usize, // interpreted/managed by User
 }
 
 static VENDOR_DEFNIED: OnceCell<VendorDefinedStruct> = OnceCell::uninit();
 
 static VENDOR_DEFNIED_DEFAULT: VendorDefinedStruct = VendorDefinedStruct {
     vendor_defined_request_handler:
-        |_vendor_context: usize,
+        |_vdm_handle: usize,
          _vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct|
          -> SpdmResult<VendorDefinedRspPayloadStruct> {
             log::info!("not implement vendor defined struct!!!\n");
             unimplemented!()
         },
-    vendor_context: 0,
+    vdm_handle: 0,
 };
 
 pub fn register_vendor_defined_struct(context: VendorDefinedStruct) -> bool {
@@ -279,7 +279,7 @@ pub fn vendor_defined_request_handler(
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     if let Ok(vds) = VENDOR_DEFNIED.try_get_or_init(|| VENDOR_DEFNIED_DEFAULT) {
-        (vds.vendor_defined_request_handler)(vds.vendor_context, vendor_defined_req_payload_struct)
+        (vds.vendor_defined_request_handler)(vds.vdm_handle, vendor_defined_req_payload_struct)
     } else {
         Err(SPDM_STATUS_INVALID_STATE_LOCAL)
     }

--- a/spdmlib/src/responder/app_message_handler.rs
+++ b/spdmlib/src/responder/app_message_handler.rs
@@ -12,7 +12,7 @@ type DispatchSecuredAppMessageCbType = for<'a> fn(
     &mut ResponderContext,
     u32,
     &[u8],
-    &[u8],
+    usize,
     &'a mut Writer,
 ) -> (SpdmResult, Option<&'a [u8]>);
 
@@ -27,7 +27,7 @@ static DEFAULT: SpdmAppMessageHandler = SpdmAppMessageHandler {
     dispatch_secured_app_message_cb: |_ctx: &mut ResponderContext,
                                       _session_id: u32,
                                       _app_buffer: &[u8],
-                                      _auxiliary_app_data: &[u8],
+                                      _app_handle: usize,
                                       _writer: &mut Writer|
      -> (SpdmResult, Option<&[u8]>) { unimplemented!() },
 };
@@ -41,13 +41,11 @@ pub fn dispatch_secured_app_message_cb<'a>(
     ctx: &mut ResponderContext,
     session_id: u32,
     app_buffer: &[u8],
-    auxiliary_app_data: &[u8],
+    app_handle: usize, // interpreted/managed by User
     writer: &'a mut Writer,
 ) -> (SpdmResult, Option<&'a [u8]>) {
     (SPDM_APP_MESSAGE_HANDLER
         .try_get_or_init(|| DEFAULT.clone())
         .unwrap_or(&DEFAULT)
-        .dispatch_secured_app_message_cb)(
-        ctx, session_id, app_buffer, auxiliary_app_data, writer
-    )
+        .dispatch_secured_app_message_cb)(ctx, session_id, app_buffer, app_handle, writer)
 }

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -189,7 +189,7 @@ impl ResponderContext {
     pub async fn process_message(
         &mut self,
         crypto_request: bool,
-        auxiliary_app_data: &[u8],
+        app_handle: usize, // interpreted/managed by User
         raw_packet: &mut [u8; RECEIVER_BUFFER_SIZE],
     ) -> Result<SpdmResult, usize> {
         let mut response_buffer = [0u8; MAX_SPDM_MSG_SIZE];
@@ -267,7 +267,7 @@ impl ResponderContext {
                                 let (status, send_buffer) = self.dispatch_secured_app_message(
                                     session_id,
                                     &spdm_buffer[..decode_size],
-                                    auxiliary_app_data,
+                                    app_handle,
                                     &mut writer,
                                 );
                                 if let Some(send_buffer) = send_buffer {
@@ -491,12 +491,12 @@ impl ResponderContext {
         &mut self,
         session_id: u32,
         bytes: &[u8],
-        auxiliary_app_data: &[u8],
+        app_handle: usize,
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
         debug!("dispatching secured app message\n");
 
-        dispatch_secured_app_message_cb(self, session_id, bytes, auxiliary_app_data, writer)
+        dispatch_secured_app_message_cb(self, session_id, bytes, app_handle, writer)
     }
 
     pub fn dispatch_message<'a>(

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_bind_p2p_stream_request.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_bind_p2p_stream_request.rs
@@ -29,7 +29,7 @@ static PCI_TDISP_DEVICE_BING_P2P_STREAM_INSTANCE: OnceCell<PciTdispDeviceBindP2p
 pub struct PciTdispDeviceBindP2pStream {
     pub pci_tdisp_device_bind_p2p_stream_cb: fn(
         //IN
-        vendor_context: usize,
+        vdm_handle: usize,
         p2p_stream_id: u8,
         //OUT
         interface_id: &mut InterfaceId,
@@ -45,7 +45,7 @@ pub fn register(context: PciTdispDeviceBindP2pStream) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceBindP2pStream = PciTdispDeviceBindP2pStream {
     pci_tdisp_device_bind_p2p_stream_cb: |//IN
-                                          _vendor_context: usize,
+                                          _vdm_handle: usize,
                                           _p2p_stream_id: u8,
                                           //OUT
                                           _interface_id: &mut InterfaceId,
@@ -55,7 +55,7 @@ static UNIMPLETEMTED: PciTdispDeviceBindP2pStream = PciTdispDeviceBindP2pStream 
 
 pub(crate) fn pci_tdisp_device_bind_p2p_stream(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     p2p_stream_id: u8,
     //OUT
     interface_id: &mut InterfaceId,
@@ -66,7 +66,7 @@ pub(crate) fn pci_tdisp_device_bind_p2p_stream(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_bind_p2p_stream_cb)(
-        vendor_context,
+        vdm_handle,
         p2p_stream_id,
         interface_id,
         tdisp_error_code,
@@ -74,7 +74,7 @@ pub(crate) fn pci_tdisp_device_bind_p2p_stream(
 }
 
 pub(crate) fn pci_tdisp_rsp_bind_p2p_stream(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_bind_p2_pstream_request = ReqBindP2PStreamRequest::read_bytes(
@@ -87,7 +87,7 @@ pub(crate) fn pci_tdisp_rsp_bind_p2p_stream(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_bind_p2p_stream(
-        vendor_context,
+        vdm_handle,
         req_bind_p2_pstream_request.p2p_stream_id,
         &mut interface_id,
         &mut tdisp_error_code,
@@ -100,7 +100,7 @@ pub(crate) fn pci_tdisp_rsp_bind_p2p_stream(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_device_interface_report.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_device_interface_report.rs
@@ -31,7 +31,7 @@ static PCI_TDISP_DEVICE_INTERFACE_REPORT_INSTANCE: OnceCell<PciTdispDeviceInterf
 pub struct PciTdispDeviceInterfaceReport {
     pub pci_tdisp_device_interface_report_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         // OUT
         interface_id: &mut InterfaceId,
         tdi_report: &mut [u8; MAX_DEVICE_REPORT_BUFFER],
@@ -57,7 +57,7 @@ static UNIMPLETEMTED: PciTdispDeviceInterfaceReport = PciTdispDeviceInterfaceRep
 
 pub(crate) fn pci_tdisp_device_interface_report(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     tdi_report: &mut [u8; MAX_DEVICE_REPORT_BUFFER],
@@ -69,7 +69,7 @@ pub(crate) fn pci_tdisp_device_interface_report(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_interface_report_cb)(
-        vendor_context,
+        vdm_handle,
         interface_id,
         tdi_report,
         tdi_report_size,
@@ -78,7 +78,7 @@ pub(crate) fn pci_tdisp_device_interface_report(
 }
 
 pub(crate) fn pci_tdisp_rsp_interface_report(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_get_device_interface_report = ReqGetDeviceInterfaceReport::read_bytes(
@@ -94,7 +94,7 @@ pub(crate) fn pci_tdisp_rsp_interface_report(
 
     // device need to check tdi state
     pci_tdisp_device_interface_report(
-        vendor_context,
+        vdm_handle,
         &mut interface_id,
         &mut tdi_report,
         &mut tdi_report_size,
@@ -108,7 +108,7 @@ pub(crate) fn pci_tdisp_rsp_interface_report(
 
     if let Some(tdisp_error_code_code) = tdisp_error_code_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_device_interface_state.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_device_interface_state.rs
@@ -29,7 +29,7 @@ static PCI_TDISP_DEVICE_INTERFACE_STATE_INSTANCE: OnceCell<PciTdispDeviceInterfa
 pub struct PciTdispDeviceInterfaceState {
     pub pci_tdisp_device_interface_state_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         // OUT
         interface_id: &mut InterfaceId,
         tdi_state: &mut TdiState,
@@ -53,7 +53,7 @@ static UNIMPLETEMTED: PciTdispDeviceInterfaceState = PciTdispDeviceInterfaceStat
 
 pub(crate) fn pci_tdisp_device_interface_state(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     tdi_state: &mut TdiState,
@@ -64,15 +64,12 @@ pub(crate) fn pci_tdisp_device_interface_state(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_interface_state_cb)(
-        vendor_context,
-        interface_id,
-        tdi_state,
-        tdisp_error_code,
+        vdm_handle, interface_id, tdi_state, tdisp_error_code
     )
 }
 
 pub(crate) fn pci_tdisp_rsp_interface_state(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let _ = ReqGetDeviceInterfaceState::read_bytes(
@@ -86,7 +83,7 @@ pub(crate) fn pci_tdisp_rsp_interface_state(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_interface_state(
-        vendor_context,
+        vdm_handle,
         &mut interface_id,
         &mut tdi_state,
         &mut tdisp_error_code,
@@ -99,7 +96,7 @@ pub(crate) fn pci_tdisp_rsp_interface_state(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_dispatcher.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_dispatcher.rs
@@ -28,7 +28,7 @@ use super::{
 };
 
 pub fn pci_tdisp_rsp_dispatcher(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     if vendor_defined_req_payload_struct.req_length < 3
@@ -42,34 +42,34 @@ pub fn pci_tdisp_rsp_dispatcher(
     ) {
         match request_response_code {
             TdispRequestResponseCode::GET_TDISP_VERSION => {
-                pci_tdisp_rsp_version(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_version(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::GET_TDISP_CAPABILITIES => {
-                pci_tdisp_rsp_capabilities(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_capabilities(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::LOCK_INTERFACE_REQUEST => {
-                pci_tdisp_rsp_lock_interface(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_lock_interface(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::GET_DEVICE_INTERFACE_REPORT => {
-                pci_tdisp_rsp_interface_report(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_interface_report(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::GET_DEVICE_INTERFACE_STATE => {
-                pci_tdisp_rsp_interface_state(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_interface_state(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::START_INTERFACE_REQUEST => {
-                pci_tdisp_rsp_start_interface(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_start_interface(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::STOP_INTERFACE_REQUEST => {
-                pci_tdisp_rsp_stop_interface(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_stop_interface(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::SET_MMIO_ATTRIBUTE_REQUEST => {
-                pci_tdisp_rsp_set_mmio_attribute(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_set_mmio_attribute(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::BIND_P2P_STREAM_REQUEST => {
-                pci_tdisp_rsp_bind_p2p_stream(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_bind_p2p_stream(vdm_handle, vendor_defined_req_payload_struct)
             }
             TdispRequestResponseCode::UNBIND_P2P_STREAM_REQUEST => {
-                pci_tdisp_rsp_unbind_p2p_stream(vendor_context, vendor_defined_req_payload_struct)
+                pci_tdisp_rsp_unbind_p2p_stream(vdm_handle, vendor_defined_req_payload_struct)
             }
             _ => {
                 let mut vendor_defined_rsp_payload_struct = VendorDefinedRspPayloadStruct {
@@ -78,7 +78,7 @@ pub fn pci_tdisp_rsp_dispatcher(
                 };
 
                 let len = write_error(
-                    vendor_context,
+                    vdm_handle,
                     TdispErrorCode::UNSUPPORTED_REQUEST,
                     0,
                     &[],
@@ -89,6 +89,6 @@ pub fn pci_tdisp_rsp_dispatcher(
             }
         }
     } else {
-        pci_tdisp_rsp_vdm_response(vendor_context, vendor_defined_req_payload_struct)
+        pci_tdisp_rsp_vdm_response(vdm_handle, vendor_defined_req_payload_struct)
     }
 }

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_lock_interface_request.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_lock_interface_request.rs
@@ -31,7 +31,7 @@ pub struct PciTdispDeviceLockInterface {
     #[allow(clippy::type_complexity)]
     pub pci_tdisp_device_lock_interface_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         flags: &LockInterfaceFlag,
         default_stream_id: u8,
         mmio_reporting_offset: u64,
@@ -52,7 +52,7 @@ pub fn register(context: PciTdispDeviceLockInterface) -> bool {
 static UNIMPLETEMTED: PciTdispDeviceLockInterface = PciTdispDeviceLockInterface {
     pci_tdisp_device_lock_interface_cb:
         |// IN
-         _vendor_context: usize,
+         _vdm_handle: usize,
          _flags: &LockInterfaceFlag,
          _default_stream_id: u8,
          _mmio_reporting_offset: u64,
@@ -67,7 +67,7 @@ static UNIMPLETEMTED: PciTdispDeviceLockInterface = PciTdispDeviceLockInterface 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn pci_tdisp_device_lock_interface(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     flags: &LockInterfaceFlag,
     default_stream_id: u8,
     mmio_reporting_offset: u64,
@@ -82,7 +82,7 @@ pub(crate) fn pci_tdisp_device_lock_interface(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_lock_interface_cb)(
-        vendor_context,
+        vdm_handle,
         flags,
         default_stream_id,
         mmio_reporting_offset,
@@ -94,7 +94,7 @@ pub(crate) fn pci_tdisp_device_lock_interface(
 }
 
 pub(crate) fn pci_tdisp_rsp_lock_interface(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_lock_interface_request = ReqLockInterfaceRequest::read_bytes(
@@ -113,7 +113,7 @@ pub(crate) fn pci_tdisp_rsp_lock_interface(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_lock_interface(
-        vendor_context,
+        vdm_handle,
         &req_lock_interface_request.flags,
         req_lock_interface_request.default_stream_id,
         req_lock_interface_request.mmio_reporting_offset,
@@ -125,7 +125,7 @@ pub(crate) fn pci_tdisp_rsp_lock_interface(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_set_mmio_attribute_request.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_set_mmio_attribute_request.rs
@@ -29,7 +29,7 @@ static PCI_TDISP_DEVICE_SET_MMIO_ATTRIBUTE_INSTANCE: OnceCell<PciTdispDeviceSetM
 pub struct PciTdispDeviceSetMmioAttribute {
     pub pci_tdisp_device_set_mmio_attribute_cb: fn(
         //IN
-        vendor_context: usize,
+        vdm_handle: usize,
         mmio_range: &TdispMmioRange,
         //OUT
         interface_id: &mut InterfaceId,
@@ -45,7 +45,7 @@ pub fn register(context: PciTdispDeviceSetMmioAttribute) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceSetMmioAttribute = PciTdispDeviceSetMmioAttribute {
     pci_tdisp_device_set_mmio_attribute_cb: |//IN
-                                             _vendor_context: usize,
+                                             _vdm_handle: usize,
                                              _mmio_range: &TdispMmioRange,
                                              //OUT
                                              _interface_id: &mut InterfaceId,
@@ -55,7 +55,7 @@ static UNIMPLETEMTED: PciTdispDeviceSetMmioAttribute = PciTdispDeviceSetMmioAttr
 
 pub(crate) fn pci_tdisp_device_set_mmio_attribute(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     mmio_range: &TdispMmioRange,
     //OUT
     interface_id: &mut InterfaceId,
@@ -66,7 +66,7 @@ pub(crate) fn pci_tdisp_device_set_mmio_attribute(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_set_mmio_attribute_cb)(
-        vendor_context,
+        vdm_handle,
         mmio_range,
         interface_id,
         tdisp_error_code,
@@ -74,7 +74,7 @@ pub(crate) fn pci_tdisp_device_set_mmio_attribute(
 }
 
 pub(crate) fn pci_tdisp_rsp_set_mmio_attribute(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_set_mmio_attribute_request = ReqSetMmioAttributeRequest::read_bytes(
@@ -87,7 +87,7 @@ pub(crate) fn pci_tdisp_rsp_set_mmio_attribute(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_set_mmio_attribute(
-        vendor_context,
+        vdm_handle,
         &req_set_mmio_attribute_request.mmio_range,
         &mut interface_id,
         &mut tdisp_error_code,
@@ -100,7 +100,7 @@ pub(crate) fn pci_tdisp_rsp_set_mmio_attribute(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_start_interface_request.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_start_interface_request.rs
@@ -29,7 +29,7 @@ static PCI_TDISP_DEVICE_START_INTERFACE_INSTANCE: OnceCell<PciTdispDeviceStartIn
 pub struct PciTdispDeviceStartInterface {
     pub pci_tdisp_device_start_interface_cb: fn(
         //IN
-        vendor_context: usize,
+        vdm_handle: usize,
         start_interface_nonce: &[u8; START_INTERFACE_NONCE_LEN],
         //OUT
         interface_id: &mut InterfaceId,
@@ -46,7 +46,7 @@ pub fn register(context: PciTdispDeviceStartInterface) -> bool {
 static UNIMPLETEMTED: PciTdispDeviceStartInterface = PciTdispDeviceStartInterface {
     pci_tdisp_device_start_interface_cb:
         |//IN
-         _vendor_context: usize,
+         _vdm_handle: usize,
          _start_interface_nonce: &[u8; START_INTERFACE_NONCE_LEN],
          //OUT
          _interface_id: &mut InterfaceId,
@@ -56,7 +56,7 @@ static UNIMPLETEMTED: PciTdispDeviceStartInterface = PciTdispDeviceStartInterfac
 
 pub(crate) fn pci_tdisp_device_start_interface(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     start_interface_nonce: &[u8; START_INTERFACE_NONCE_LEN],
     //OUT
     interface_id: &mut InterfaceId,
@@ -67,7 +67,7 @@ pub(crate) fn pci_tdisp_device_start_interface(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_start_interface_cb)(
-        vendor_context,
+        vdm_handle,
         start_interface_nonce,
         interface_id,
         tdisp_error_code,
@@ -75,7 +75,7 @@ pub(crate) fn pci_tdisp_device_start_interface(
 }
 
 pub(crate) fn pci_tdisp_rsp_start_interface(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_start_interface_request = ReqStartInterfaceRequest::read_bytes(
@@ -88,7 +88,7 @@ pub(crate) fn pci_tdisp_rsp_start_interface(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_start_interface(
-        vendor_context,
+        vdm_handle,
         &req_start_interface_request.start_interface_nonce,
         &mut interface_id,
         &mut tdisp_error_code,
@@ -101,7 +101,7 @@ pub(crate) fn pci_tdisp_rsp_start_interface(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_stop_interface_request.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_stop_interface_request.rs
@@ -29,7 +29,7 @@ static PCI_TDISP_DEVICE_STOP_INTERFACE_INSTANCE: OnceCell<PciTdispDeviceStopInte
 pub struct PciTdispDeviceStopInterface {
     pub pci_tdisp_device_stop_interface_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         // OUT
         interface_id: &mut InterfaceId,
         tdisp_error_code: &mut Option<TdispErrorCode>,
@@ -44,7 +44,7 @@ pub fn register(context: PciTdispDeviceStopInterface) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceStopInterface = PciTdispDeviceStopInterface {
     pci_tdisp_device_stop_interface_cb: |// IN
-                                         _vendor_context: usize,
+                                         _vdm_handle: usize,
                                          // OUT
                                          _interface_id: &mut InterfaceId,
                                          _tdisp_error_code: &mut Option<TdispErrorCode>|
@@ -53,7 +53,7 @@ static UNIMPLETEMTED: PciTdispDeviceStopInterface = PciTdispDeviceStopInterface 
 
 pub(crate) fn pci_tdisp_device_stop_interface(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     tdisp_error_code: &mut Option<TdispErrorCode>,
@@ -62,11 +62,11 @@ pub(crate) fn pci_tdisp_device_stop_interface(
         .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
-        .pci_tdisp_device_stop_interface_cb)(vendor_context, interface_id, tdisp_error_code)
+        .pci_tdisp_device_stop_interface_cb)(vdm_handle, interface_id, tdisp_error_code)
 }
 
 pub(crate) fn pci_tdisp_rsp_stop_interface(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let _ = ReqStopInterfaceRequest::read_bytes(
@@ -78,7 +78,7 @@ pub(crate) fn pci_tdisp_rsp_stop_interface(
     let mut interface_id = InterfaceId::default();
     let mut tdisp_error_code = None;
 
-    pci_tdisp_device_stop_interface(vendor_context, &mut interface_id, &mut tdisp_error_code)?;
+    pci_tdisp_device_stop_interface(vdm_handle, &mut interface_id, &mut tdisp_error_code)?;
 
     let mut vendor_defined_rsp_payload_struct = VendorDefinedRspPayloadStruct {
         rsp_length: 0,
@@ -87,7 +87,7 @@ pub(crate) fn pci_tdisp_rsp_stop_interface(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_tdisp_capabilities.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_tdisp_capabilities.rs
@@ -30,7 +30,7 @@ pub struct PciTdispDeviceCapabilities {
     #[allow(clippy::type_complexity)]
     pub pci_tdisp_device_capabilities_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         tsm_caps: u32,
         // OUT
         interface_id: &mut InterfaceId,
@@ -52,7 +52,7 @@ pub fn register(context: PciTdispDeviceCapabilities) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceCapabilities = PciTdispDeviceCapabilities {
     pci_tdisp_device_capabilities_cb: |// IN
-                                       _vendor_context: usize,
+                                       _vdm_handle: usize,
                                        _tsm_caps: u32,
                                        // OUT
                                        _interface_id: &mut InterfaceId,
@@ -69,7 +69,7 @@ static UNIMPLETEMTED: PciTdispDeviceCapabilities = PciTdispDeviceCapabilities {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn pci_tdisp_device_capabilities(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     tsm_caps: u32,
     // OUT
     interface_id: &mut InterfaceId,
@@ -87,7 +87,7 @@ pub(crate) fn pci_tdisp_device_capabilities(
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_capabilities_cb)(
         // IN
-        vendor_context,
+        vdm_handle,
         tsm_caps,
         // OUT
         interface_id,
@@ -102,7 +102,7 @@ pub(crate) fn pci_tdisp_device_capabilities(
 }
 
 pub(crate) fn pci_tdisp_rsp_capabilities(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_get_tdisp_capabilities = ReqGetTdispCapabilities::read_bytes(
@@ -121,7 +121,7 @@ pub(crate) fn pci_tdisp_rsp_capabilities(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_capabilities(
-        vendor_context,
+        vdm_handle,
         req_get_tdisp_capabilities.tsm_caps,
         &mut interface_id,
         &mut dsm_caps,
@@ -140,7 +140,7 @@ pub(crate) fn pci_tdisp_rsp_capabilities(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_tdisp_error.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_tdisp_error.rs
@@ -21,7 +21,7 @@ pub struct PciTdispDeviceError {
     #[allow(clippy::type_complexity)]
     pub pci_tdisp_device_error_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         // OUT
         interface_id: &mut InterfaceId,
     ) -> SpdmResult,
@@ -35,7 +35,7 @@ pub fn register(context: PciTdispDeviceError) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceError = PciTdispDeviceError {
     pci_tdisp_device_error_cb: |// IN
-                                _vendor_context: usize,
+                                _vdm_handle: usize,
                                 // OUT
                                 _interface_id: &mut InterfaceId|
      -> SpdmResult { unimplemented!() },
@@ -43,7 +43,7 @@ static UNIMPLETEMTED: PciTdispDeviceError = PciTdispDeviceError {
 
 pub(crate) fn pci_tdisp_device_error(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
 ) -> SpdmResult {
@@ -53,14 +53,14 @@ pub(crate) fn pci_tdisp_device_error(
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_error_cb)(
         // IN
-        vendor_context,
+        vdm_handle,
         // OUT
         interface_id,
     )
 }
 
 pub(crate) fn write_error(
-    vendor_context: usize,
+    vdm_handle: usize,
     error_code: TdispErrorCode,
     error_data: u32,
     ext_error_data: &[u8],
@@ -70,7 +70,7 @@ pub(crate) fn write_error(
 
     let mut interface_id = InterfaceId::default();
 
-    pci_tdisp_device_error(vendor_context, &mut interface_id)?;
+    pci_tdisp_device_error(vdm_handle, &mut interface_id)?;
 
     let len1 = RspTdispError {
         message_header: TdispMessageHeader {

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_tdisp_version.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_tdisp_version.rs
@@ -26,7 +26,7 @@ pub struct PciTdispDeviceVersion {
     #[allow(clippy::type_complexity)]
     pub pci_tdisp_device_version_cb: fn(
         // IN
-        vendor_context: usize,
+        vdm_handle: usize,
         // OUT
         interface_id: &mut InterfaceId,
         version_num_count: &mut u8,
@@ -42,7 +42,7 @@ pub fn register(context: PciTdispDeviceVersion) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceVersion = PciTdispDeviceVersion {
     pci_tdisp_device_version_cb: |// IN
-                                  _vendor_context: usize,
+                                  _vdm_handle: usize,
                                   // OUT
                                   _interface_id: &mut InterfaceId,
                                   _version_num_count: &mut u8,
@@ -53,7 +53,7 @@ static UNIMPLETEMTED: PciTdispDeviceVersion = PciTdispDeviceVersion {
 
 pub(crate) fn pci_tdisp_device_version(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     version_num_count: &mut u8,
@@ -65,7 +65,7 @@ pub(crate) fn pci_tdisp_device_version(
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_version_cb)(
         // IN
-        vendor_context,
+        vdm_handle,
         // OUT
         interface_id,
         version_num_count,
@@ -74,7 +74,7 @@ pub(crate) fn pci_tdisp_device_version(
 }
 
 pub(crate) fn pci_tdisp_rsp_version(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let _ = ReqGetTdispVersion::read_bytes(
@@ -88,7 +88,7 @@ pub(crate) fn pci_tdisp_rsp_version(
     let mut version_num_entry = [TdispVersion::default(); MAX_TDISP_VERSION_COUNT];
 
     pci_tdisp_device_version(
-        vendor_context,
+        vdm_handle,
         &mut interface_id,
         &mut version_num_count,
         &mut version_num_entry,

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_unbind_p2p_stream_request.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_unbind_p2p_stream_request.rs
@@ -29,7 +29,7 @@ static PCI_TDISP_DEVICE_UNBING_P2P_STREAM_INSTANCE: OnceCell<PciTdispDeviceUnBin
 pub struct PciTdispDeviceUnBindP2pStream {
     pub pci_tdisp_device_unbind_p2p_stream_cb: fn(
         //IN
-        vendor_context: usize,
+        vdm_handle: usize,
         p2p_stream_id: u8,
         //OUT
         interface_id: &mut InterfaceId,
@@ -45,7 +45,7 @@ pub fn register(context: PciTdispDeviceUnBindP2pStream) -> bool {
 
 static UNIMPLETEMTED: PciTdispDeviceUnBindP2pStream = PciTdispDeviceUnBindP2pStream {
     pci_tdisp_device_unbind_p2p_stream_cb: |//IN
-                                            _vendor_context: usize,
+                                            _vdm_handle: usize,
                                             _p2p_stream_id: u8,
                                             //OUT
                                             _interface_id: &mut InterfaceId,
@@ -55,7 +55,7 @@ static UNIMPLETEMTED: PciTdispDeviceUnBindP2pStream = PciTdispDeviceUnBindP2pStr
 
 pub(crate) fn pci_tdisp_device_unbind_p2p_stream(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     p2p_stream_id: u8,
     //OUT
     interface_id: &mut InterfaceId,
@@ -66,7 +66,7 @@ pub(crate) fn pci_tdisp_device_unbind_p2p_stream(
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
         .pci_tdisp_device_unbind_p2p_stream_cb)(
-        vendor_context,
+        vdm_handle,
         p2p_stream_id,
         interface_id,
         tdisp_error_code,
@@ -74,7 +74,7 @@ pub(crate) fn pci_tdisp_device_unbind_p2p_stream(
 }
 
 pub(crate) fn pci_tdisp_rsp_unbind_p2p_stream(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     let req_un_bind_p2_pstream_request = ReqUnBindP2PStreamRequest::read_bytes(
@@ -87,7 +87,7 @@ pub(crate) fn pci_tdisp_rsp_unbind_p2p_stream(
     let mut tdisp_error_code = None;
 
     pci_tdisp_device_unbind_p2p_stream(
-        vendor_context,
+        vdm_handle,
         req_un_bind_p2_pstream_request.p2p_stream_id,
         &mut interface_id,
         &mut tdisp_error_code,
@@ -100,7 +100,7 @@ pub(crate) fn pci_tdisp_rsp_unbind_p2p_stream(
 
     if let Some(tdisp_error_code) = tdisp_error_code {
         let len = write_error(
-            vendor_context,
+            vdm_handle,
             tdisp_error_code,
             0,
             &[],

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_vdm_response.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_vdm_response.rs
@@ -15,7 +15,7 @@ static PCI_TDISP_DEVICE_VDM_RESPONSE_INSTANCE: OnceCell<PciTdispDeviceVdmRespons
 pub struct PciTdispDeviceVdmResponse {
     pub pci_tdisp_device_vdm_response_cb: fn(
         //IN
-        vendor_context: usize,
+        vdm_handle: usize,
         vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
     ) -> SpdmResult<VendorDefinedRspPayloadStruct>,
 }
@@ -29,26 +29,26 @@ pub fn register(context: PciTdispDeviceVdmResponse) -> bool {
 static UNIMPLETEMTED: PciTdispDeviceVdmResponse = PciTdispDeviceVdmResponse {
     pci_tdisp_device_vdm_response_cb:
         |//IN
-         _vendor_context: usize,
+         _vdm_handle: usize,
          _vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct|
          -> SpdmResult<VendorDefinedRspPayloadStruct> { unimplemented!() },
 };
 
 pub(crate) fn pci_tdisp_device_vdm_response(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     (PCI_TDISP_DEVICE_VDM_RESPONSE_INSTANCE
         .try_get_or_init(|| UNIMPLETEMTED.clone())
         .ok()
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?
-        .pci_tdisp_device_vdm_response_cb)(vendor_context, vendor_defined_req_payload_struct)
+        .pci_tdisp_device_vdm_response_cb)(vdm_handle, vendor_defined_req_payload_struct)
 }
 
 pub(crate) fn pci_tdisp_rsp_vdm_response(
-    vendor_context: usize,
+    vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
-    pci_tdisp_device_vdm_response(vendor_context, vendor_defined_req_payload_struct)
+    pci_tdisp_device_vdm_response(vdm_handle, vendor_defined_req_payload_struct)
 }

--- a/test/spdm-responder-emu/src/spdm_device_tdisp_example.rs
+++ b/test/spdm-responder-emu/src/spdm_device_tdisp_example.rs
@@ -151,7 +151,7 @@ pub struct DeviceContext {
 #[allow(clippy::too_many_arguments)]
 fn pci_tdisp_device_capabilities(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     _tsm_caps: u32,
     // OUT
     interface_id: &mut InterfaceId,
@@ -163,7 +163,7 @@ fn pci_tdisp_device_capabilities(
     num_req_all: &mut u8,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &*device_context as &DeviceContext };
 
@@ -181,11 +181,11 @@ fn pci_tdisp_device_capabilities(
 
 fn pci_tdisp_device_error(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -198,14 +198,14 @@ fn pci_tdisp_device_error(
 
 fn pci_tdisp_device_interface_report(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     tdi_report: &mut [u8; MAX_DEVICE_REPORT_BUFFER],
     tdi_report_size: &mut usize,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -244,13 +244,13 @@ fn pci_tdisp_device_interface_report(
 
 fn pci_tdisp_device_interface_state(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     tdi_state: &mut TdiState,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -264,7 +264,7 @@ fn pci_tdisp_device_interface_state(
 #[allow(clippy::too_many_arguments)]
 fn pci_tdisp_device_lock_interface(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     flags: &LockInterfaceFlag,
     default_stream_id: u8,
     mmio_reporting_offset: u64,
@@ -274,7 +274,7 @@ fn pci_tdisp_device_lock_interface(
     start_interface_nonce: &mut [u8; START_INTERFACE_NONCE_LEN],
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -306,13 +306,13 @@ fn pci_tdisp_device_lock_interface(
 
 fn pci_tdisp_device_start_interface(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     start_interface_nonce: &[u8; START_INTERFACE_NONCE_LEN],
     //OUT
     interface_id: &mut InterfaceId,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -332,12 +332,12 @@ fn pci_tdisp_device_start_interface(
 
 fn pci_tdisp_device_stop_interface(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -356,13 +356,13 @@ fn pci_tdisp_device_stop_interface(
 
 fn pci_tdisp_device_bind_p2p_stream(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     p2p_stream_id: u8,
     //OUT
     interface_id: &mut InterfaceId,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -381,13 +381,13 @@ fn pci_tdisp_device_bind_p2p_stream(
 
 fn pci_tdisp_device_unbind_p2p_stream(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     p2p_stream_id: u8,
     //OUT
     interface_id: &mut InterfaceId,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -409,13 +409,13 @@ fn pci_tdisp_device_unbind_p2p_stream(
 
 fn pci_tdisp_device_set_mmio_attribute(
     //IN
-    vendor_context: usize,
+    vdm_handle: usize,
     _mmio_range: &TdispMmioRange,
     //OUT
     interface_id: &mut InterfaceId,
     tdisp_error_code: &mut Option<TdispErrorCode>,
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 
@@ -432,7 +432,7 @@ fn pci_tdisp_device_set_mmio_attribute(
 
 fn pci_tdisp_device_vdm_response(
     //IN
-    _vendor_context: usize,
+    _vdm_handle: usize,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     println!(
@@ -455,13 +455,13 @@ fn pci_tdisp_device_vdm_response(
 
 fn pci_tdisp_device_version(
     // IN
-    vendor_context: usize,
+    vdm_handle: usize,
     // OUT
     interface_id: &mut InterfaceId,
     version_num_count: &mut u8,
     version_num_entry: &mut [TdispVersion; MAX_TDISP_VERSION_COUNT],
 ) -> SpdmResult {
-    let device_context = vendor_context as *mut DeviceContext;
+    let device_context = vdm_handle as *mut DeviceContext;
 
     let device_context = unsafe { &mut *device_context as &mut DeviceContext };
 

--- a/test/spdmlib-test/src/common/device_io.rs
+++ b/test/spdmlib-test/src/common/device_io.rs
@@ -95,7 +95,7 @@ impl SpdmDeviceIo for FakeSpdmDeviceIo {
         let mut raw_packet = [0u8; RECEIVER_BUFFER_SIZE];
 
         if responder
-            .process_message(false, &[0], &mut raw_packet)
+            .process_message(false, 0, &mut raw_packet)
             .await
             .is_err()
         {

--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -500,7 +500,7 @@ impl ResponderRunner {
             );
             let raw_packet = &mut [0u8; spdmlib::config::RECEIVER_BUFFER_SIZE];
             loop {
-                let result = context.process_message(false, &[0], raw_packet).await;
+                let result = context.process_message(false, 0, raw_packet).await;
                 match result {
                     Err(nread) => {
                         if nread == 0 {

--- a/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
@@ -57,7 +57,7 @@ fn test_case0_handle_spdm_vendor_defined_request() {
 
     register_vendor_defined_struct(VendorDefinedStruct {
         vendor_defined_request_handler: vendor_defined_func,
-        vendor_context: 0,
+        vdm_handle: 0,
     });
 
     if let Ok(vendor_defined_res_payload_struct) =


### PR DESCRIPTION
fix #137 
fix #37

1. change auxiliary_app_data to app_handle
2. change vendor_context to vdm_handle
3. use same type for them, change to usize
4. add comment: interpreted/managed by User for new parameter.