### PR TITLE
Pass vendor_id to vendor defined response handler.

### DIFF
--- a/idekm/src/pci_ide_km_responder/pci_ide_km_rsp_dispatcher.rs
+++ b/idekm/src/pci_ide_km_responder/pci_ide_km_rsp_dispatcher.rs
@@ -7,11 +7,15 @@ use super::{
     pci_ide_km_rsp_query,
 };
 use crate::pci_idekm::{
-    KEY_PROG_OBJECT_ID, K_SET_GO_OBJECT_ID, K_SET_STOP_OBJECT_ID, QUERY_OBJECT_ID,
+    vendor_id, IDEKM_PROTOCOL_ID, KEY_PROG_OBJECT_ID, K_SET_GO_OBJECT_ID, K_SET_STOP_OBJECT_ID,
+    QUERY_OBJECT_ID,
 };
 use spdmlib::{
     error::{SpdmResult, SPDM_STATUS_INVALID_MSG_FIELD},
-    message::{VendorDefinedReqPayloadStruct, VendorDefinedRspPayloadStruct, VendorDefinedStruct},
+    message::{
+        VendorDefinedReqPayloadStruct, VendorDefinedRspPayloadStruct, VendorDefinedStruct,
+        VendorIDStruct,
+    },
 };
 
 pub const PCI_IDE_KM_INSTANCE: VendorDefinedStruct = VendorDefinedStruct {
@@ -21,9 +25,13 @@ pub const PCI_IDE_KM_INSTANCE: VendorDefinedStruct = VendorDefinedStruct {
 
 pub fn pci_ide_km_rsp_dispatcher(
     _vdm_handle: usize,
+    vendor_id_struct: &VendorIDStruct,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
-    if vendor_defined_req_payload_struct.req_length < 2 {
+    if vendor_defined_req_payload_struct.req_length < 2
+        || vendor_id_struct != &vendor_id()
+        || vendor_defined_req_payload_struct.vendor_defined_req_payload[0] != IDEKM_PROTOCOL_ID
+    {
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
 

--- a/spdmlib/src/message/vendor.rs
+++ b/spdmlib/src/message/vendor.rs
@@ -82,6 +82,27 @@ impl Codec for VendorIDStruct {
     }
 }
 
+impl PartialEq for VendorIDStruct {
+    fn eq(&self, vid: &VendorIDStruct) -> bool {
+        if self.len != vid.len {
+            false
+        } else {
+            self.vendor_id[..self.len as usize] == vid.vendor_id[..vid.len as usize]
+        }
+    }
+}
+
+impl Eq for VendorIDStruct {}
+
+impl Default for VendorIDStruct {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            vendor_id: [0u8; MAX_SPDM_VENDOR_DEFINED_VENDOR_ID_LEN],
+        }
+    }
+}
+
 #[derive(Debug, Clone, ZeroizeOnDrop)]
 pub struct VendorDefinedReqPayloadStruct {
     pub req_length: u16,

--- a/spdmlib/src/responder/vendor_rsp.rs
+++ b/spdmlib/src/responder/vendor_rsp.rs
@@ -63,8 +63,11 @@ impl ResponderContext {
         let standard_id = vendor_defined_request_payload.standard_id;
         let vendor_id = vendor_defined_request_payload.vendor_id;
         let req_payload = vendor_defined_request_payload.req_payload;
-        let rsp_payload =
-            self.respond_to_vendor_defined_request(&req_payload, vendor_defined_request_handler);
+        let rsp_payload = self.respond_to_vendor_defined_request(
+            &req_payload,
+            &vendor_id,
+            vendor_defined_request_handler,
+        );
         if let Err(e) = rsp_payload {
             self.write_spdm_error(SpdmErrorCode::SpdmErrorUnspecified, 0, writer);
             return (Err(e), Some(writer.used_slice()));
@@ -100,11 +103,15 @@ impl ResponderContext {
     pub fn respond_to_vendor_defined_request<F>(
         &mut self,
         req: &VendorDefinedReqPayloadStruct,
+        vendor_id_struct: &VendorIDStruct,
         verdor_defined_func: F,
     ) -> SpdmResult<VendorDefinedRspPayloadStruct>
     where
-        F: Fn(&VendorDefinedReqPayloadStruct) -> SpdmResult<VendorDefinedRspPayloadStruct>,
+        F: Fn(
+            &VendorIDStruct,
+            &VendorDefinedReqPayloadStruct,
+        ) -> SpdmResult<VendorDefinedRspPayloadStruct>,
     {
-        verdor_defined_func(req)
+        verdor_defined_func(vendor_id_struct, req)
     }
 }

--- a/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_dispatcher.rs
+++ b/tdisp/src/pci_tdisp_responder/pci_tdisp_rsp_dispatcher.rs
@@ -6,12 +6,12 @@ use core::convert::TryFrom;
 use spdmlib::{
     error::{SpdmResult, SPDM_STATUS_INVALID_MSG_FIELD},
     message::{
-        VendorDefinedReqPayloadStruct, VendorDefinedRspPayloadStruct,
+        VendorDefinedReqPayloadStruct, VendorDefinedRspPayloadStruct, VendorIDStruct,
         MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE,
     },
 };
 
-use crate::pci_tdisp::{TdispErrorCode, TdispRequestResponseCode, TDISP_PROTOCOL_ID};
+use crate::pci_tdisp::{vendor_id, TdispErrorCode, TdispRequestResponseCode, TDISP_PROTOCOL_ID};
 
 use super::{
     pci_tdisp_rsp_bind_p2p_stream_request::pci_tdisp_rsp_bind_p2p_stream,
@@ -29,9 +29,11 @@ use super::{
 
 pub fn pci_tdisp_rsp_dispatcher(
     vdm_handle: usize,
+    vendor_id_struct: &VendorIDStruct,
     vendor_defined_req_payload_struct: &VendorDefinedReqPayloadStruct,
 ) -> SpdmResult<VendorDefinedRspPayloadStruct> {
     if vendor_defined_req_payload_struct.req_length < 3
+        || vendor_id_struct != &vendor_id()
         || vendor_defined_req_payload_struct.vendor_defined_req_payload[0] != TDISP_PROTOCOL_ID
     {
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);

--- a/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
@@ -41,8 +41,10 @@ fn test_case0_handle_spdm_vendor_defined_request() {
 
     let vendor_defined_func: for<'r> fn(
         usize,
+        &VendorIDStruct,
         &'r vendor::VendorDefinedReqPayloadStruct,
     ) -> Result<_, _> = |_: usize,
+                         _: &VendorIDStruct,
                          _vendor_defined_req_payload_struct|
      -> SpdmResult<VendorDefinedRspPayloadStruct> {
         let mut vendor_defined_res_payload_struct = VendorDefinedRspPayloadStruct {
@@ -60,9 +62,11 @@ fn test_case0_handle_spdm_vendor_defined_request() {
         vdm_handle: 0,
     });
 
-    if let Ok(vendor_defined_res_payload_struct) =
-        responder.respond_to_vendor_defined_request(&req, vendor_defined_request_handler)
-    {
+    if let Ok(vendor_defined_res_payload_struct) = responder.respond_to_vendor_defined_request(
+        &req,
+        &VendorIDStruct::default(),
+        vendor_defined_request_handler,
+    ) {
         assert_eq!(vendor_defined_res_payload_struct.rsp_length, 8);
         assert_eq!(
             vendor_defined_res_payload_struct.vendor_defined_rsp_payload[0],


### PR DESCRIPTION
currently, just vendor defined request buffer is passed to vendor defined response handler, the vendor id info is missed.
This patch is to add vendor_id parameter to vendor defined response handler.