### PR TITLE
Test: calculate stack size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,5 +189,18 @@ To run a specific test, use `cargo test <test_func_name>`
 
 To run test with println!() message, use `cargo test -- --nocapture`
 
+### Stack usage
+
+```
+# Run responder and requester with "test_stack_size" feature
+cargo run --no-default-features -p spdm-responder-emu --features="spdm-ring,test_stack_size"
+cargo run --no-default-features -p spdm-requester-emu --features="spdm-ring,test_stack_size"
+
+# With "hashed-transcript-data"
+cargo run --no-default-features -p spdm-responder-emu --features="spdm-ring,hashed-transcript-data,test_stack_size"
+cargo run --no-default-features -p spdm-requester-emu --features="spdm-ring,hashed-transcript-data,test_stack_size"
+
+```
+
 ## Known limitation
 This package is only the sample code to show the concept. It does not have a full validation such as robustness functional test and fuzzing test. It does not meet the production quality yet. Any codes including the API definition, the libary and the drivers are subject to change.

--- a/test/spdm-requester-emu/Cargo.toml
+++ b/test/spdm-requester-emu/Cargo.toml
@@ -15,6 +15,8 @@ pcidoe_transport = { path = "../../pcidoe_transport" }
 log = "0.4.13"
 simple_logger = "1.11.0"
 
+td-benchmark = { git = "https://github.com/confidential-containers/td-shim.git", default-features = false,  optional = true }
+
 [features]
 default = ["spdm-emu/default"]
 mut-auth = ["spdm-emu/mut-auth"]
@@ -22,3 +24,4 @@ spdm-ring = ["spdm-emu/spdm-ring"]
 spdm-mbedtls = ["spdm-emu/spdm-mbedtls"]
 hashed-transcript-data = ["spdm-emu/hashed-transcript-data"]
 spdm-mbedtls-hashed-transcript-data = ["spdm-emu/spdm-mbedtls-hashed-transcript-data"]
+test_stack_size = ["td-benchmark"]

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -339,6 +339,13 @@ fn new_logger_from_env() -> SimpleLogger {
 }
 
 fn main() {
+    #[cfg(feature = "test_stack_size")]
+    td_benchmark::StackProfiling::init(
+        0x5aa5_5aa5_5aa5_5aa5,
+        0x200000 -
+        0x200, // main function stack
+    );
+
     new_logger_from_env().init().unwrap();
 
     spdmlib::secret::psk::register(SECRET_PSK_IMPL_INSTANCE.clone());
@@ -373,6 +380,15 @@ fn main() {
 
     let socket_io_transport = &mut SocketIoTransport::new(&mut socket);
     test_spdm(socket_io_transport, transport_encap);
+    #[cfg(feature = "test_stack_size")]
+    {
+        let value =
+            td_benchmark::StackProfiling::stack_usage().unwrap();
+        println!(
+            "max stack usage {}",
+            value
+        );
+    }
 
     send_receive_stop(&mut socket, transport_encap, transport_type);
 }

--- a/test/spdm-responder-emu/Cargo.toml
+++ b/test/spdm-responder-emu/Cargo.toml
@@ -14,10 +14,13 @@ mctp_transport = { path = "../../mctp_transport" }
 pcidoe_transport = { path = "../../pcidoe_transport" }
 simple_logger = "1.11.0"
 log = "0.4.13"
+td-benchmark = { git = "https://github.com/confidential-containers/td-shim.git", default-features = false,  optional = true }
 
 [features]
+default = ["spdm-ring", "test_stack_size"]
 mut-auth = ["spdm-emu/mut-auth"]
 spdm-ring = ["spdm-emu/spdm-ring"]
 spdm-mbedtls = ["spdm-emu/spdm-mbedtls"]
 hashed-transcript-data = ["spdm-emu/hashed-transcript-data"]
 spdm-mbedtls-hashed-transcript-data = ["spdm-emu/spdm-mbedtls-hashed-transcript-data"]
+test_stack_size = ["td-benchmark"]

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -81,6 +81,13 @@ fn new_logger_from_env() -> SimpleLogger {
 }
 
 fn main() {
+    #[cfg(feature = "test_stack_size")]
+    td_benchmark::StackProfiling::init(
+        0x5aa5_5aa5_5aa5_5aa5,
+        0x200000 -
+        0x200, // main function stack
+    );
+
     new_logger_from_env().init().unwrap();
 
     #[cfg(feature = "spdm-mbedtls")]
@@ -127,6 +134,15 @@ fn main() {
             }
             if !need_continue {
                 // TBD: return or break??
+                #[cfg(feature = "test_stack_size")]
+                {
+                    let value =
+                        td_benchmark::StackProfiling::stack_usage().unwrap();
+                    println!(
+                        "max stack usage: {}",
+                        value
+                    );
+                }
                 return;
             }
         }


### PR DESCRIPTION
Run responder and requester with "test_stack_size" feature cargo run --no-default-features -p spdm-responder-emu --features="spdm-ring,test_stack_size" cargo run --no-default-features -p spdm-requester-emu --features="spdm-ring,test_stack_size"

Run With "hashed-transcript-data"
cargo run --no-default-features -p spdm-responder-emu --features="spdm-ring,hashed-transcript-data,test_stack_size" cargo run --no-default-features -p spdm-requester-emu --features="spdm-ring,hashed-transcript-data,test_stack_size"