### PR TITLE
add active_tasks_count api.

### DIFF
--- a/executor/src/executor.rs
+++ b/executor/src/executor.rs
@@ -121,6 +121,14 @@ impl Executor {
 
         tasks.front().is_some()
     }
+
+    pub fn active_tasks_count(&self) -> usize {
+        if let Some(tl) = &self.tasks {
+            tl.len()
+        } else {
+            0
+        }
+    }
 }
 
 pub(crate) static DEFAULT_EXECUTOR: Mutex<Executor> = Mutex::new(Executor { tasks: None });

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -38,3 +38,7 @@ where
 pub fn poll_tasks() -> bool {
     DEFAULT_EXECUTOR.lock().poll_tasks()
 }
+
+pub fn active_tasks_count() -> usize {
+    DEFAULT_EXECUTOR.lock().active_tasks_count()
+}


### PR DESCRIPTION
currently, executor user can't know how much of tasks are in active state.
This patch provide such support.