### PR TITLE
Test: add stack measurement method

### DIFF
--- a/test/spdm-requester-emu/Cargo.toml
+++ b/test/spdm-requester-emu/Cargo.toml
@@ -21,9 +21,10 @@ spin = { version = "0.9.8" }
 tokio = { version = "1.30.0", features = ["full"] }
 executor = { path = "../../executor" }
 maybe-async = "0.2.7"
+td-benchmark = { git = "https://github.com/confidential-containers/td-shim.git", default-features = false, optional = true }
 
 [features]
-default = ["spdm-emu/default", "async-executor"]
+default = ["spdm-emu/default", "async-executor", "test_stack_size"]
 mut-auth = ["spdm-emu/mut-auth"]
 spdm-ring = ["spdm-emu/spdm-ring"]
 spdm-mbedtls = ["spdm-emu/spdm-mbedtls"]
@@ -31,3 +32,4 @@ hashed-transcript-data = ["spdm-emu/hashed-transcript-data"]
 async-executor = ["spdm-emu/async-executor"]
 async-tokio = ["spdm-emu/async-tokio"]
 is_sync = ["spdm-emu/is_sync", "spdmlib/is_sync", "maybe-async/is_sync", "idekm/is_sync", "tdisp/is_sync", "mctp_transport/is_sync", "pcidoe_transport/is_sync"]
+test_stack_size = ["td-benchmark"]

--- a/test/spdm-responder-emu/Cargo.toml
+++ b/test/spdm-responder-emu/Cargo.toml
@@ -22,9 +22,10 @@ tokio = { version = "1.30.0", features = ["full"] }
 executor = { path = "../../executor" }
 zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
 maybe-async = "0.2.7"
+td-benchmark = { git = "https://github.com/confidential-containers/td-shim.git", default-features = false, optional = true }
 
 [features]
-default = ["spdm-emu/default", "async-executor"]
+default = ["spdm-emu/default", "async-executor", "test_stack_size"]
 mut-auth = ["spdm-emu/mut-auth", "async-executor"]
 mandatory-mut-auth = ["mut-auth", "spdm-emu/mandatory-mut-auth"]
 spdm-ring = ["spdm-emu/spdm-ring"]
@@ -33,3 +34,4 @@ hashed-transcript-data = ["spdm-emu/hashed-transcript-data"]
 async-executor = ["spdm-emu/async-executor"]
 async-tokio = ["spdm-emu/async-tokio"]
 is_sync = ["spdm-emu/is_sync", "spdmlib/is_sync", "maybe-async/is_sync", "idekm/is_sync", "tdisp/is_sync", "mctp_transport/is_sync", "pcidoe_transport/is_sync"]
+test_stack_size = ["td-benchmark"]

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -119,7 +119,21 @@ fn new_logger_from_env() -> SimpleLogger {
     SimpleLogger::new().with_utc_timestamps().with_level(level)
 }
 
+#[cfg(feature = "test_stack_size")]
 fn emu_main() {
+    td_benchmark::StackProfiling::init(
+        0x5aa5_5aa5_5aa5_5aa5,
+        EMU_STACK_SIZE - 0x40000, // main function stack
+    );
+    emu_main_inner()
+}
+
+#[cfg(not(feature = "test_stack_size"))]
+fn emu_main() {
+    emu_main_inner()
+}
+
+fn emu_main_inner() {
     new_logger_from_env().init().unwrap();
 
     #[cfg(feature = "spdm-mbedtls")]
@@ -225,6 +239,11 @@ fn emu_main() {
 
             if !need_continue {
                 // TBD: return or break??
+                #[cfg(feature = "test_stack_size")]
+                {
+                    let value = td_benchmark::StackProfiling::stack_usage().unwrap();
+                    println!("max stack usage: {}", value);
+                }
                 return;
             }
         }


### PR DESCRIPTION
Ref: #34 

Test: Spmd-requester-emu stack:

```
cargo run --release -p spdm-requester-emu --no-default-features --features=spdm-ring,hashed-transcript-data,async-executor,test_stack_size
```

Test: Spdm-responder-emu stack:

```
 cargo run --release -p spdm-responder-emu --no-default-features --features=spdm-ring,hashed-transcript-data,async-executor,test_stack_size
```

