### PR TITLE
add assert for signature length check to stop API misuse.

### DIFF
--- a/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
@@ -120,7 +120,11 @@ fn asym_verify(
 // add ASN.1 for the ECDSA binary signature
 fn ecc_signature_bin_to_der(signature: &[u8], der_signature: &mut [u8]) -> SpdmResult<usize> {
     let sign_size = signature.len();
-    assert_eq!(sign_size % 2, 0);
+    assert!(
+        // prevent API misuse
+        sign_size == crate::protocol::ECDSA_ECC_NIST_P256_KEY_SIZE
+            || sign_size == crate::protocol::ECDSA_ECC_NIST_P384_KEY_SIZE
+    );
     let half_size = sign_size / 2;
 
     let mut r_index = half_size;
@@ -205,7 +209,7 @@ mod tests {
     }
     #[test]
     fn test_case1_ecc_signature_bin_to_der() {
-        let signature = &mut [0x00u8; 32];
+        let signature = &mut [0x00u8; 64];
         for i in 10..signature.len() {
             signature[i] = 0xff;
         }
@@ -213,7 +217,7 @@ mod tests {
         let der_signature = &mut [0u8; 64];
 
         let der_sign_size = ecc_signature_bin_to_der(signature, der_signature).unwrap();
-        assert_eq!(der_sign_size, 30);
+        assert_eq!(der_sign_size, 62);
     }
     #[test]
     fn test_case2_ecc_signature_bin_to_der() {

--- a/spdmlib_crypto_mbedtls/src/asym_verify_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/asym_verify_impl.rs
@@ -74,6 +74,11 @@ fn asym_verify(
 // add ASN.1 for the ECDSA binary signature
 fn ecc_signature_bin_to_der(signature: &[u8], der_signature: &mut [u8]) -> SpdmResult<usize> {
     let sign_size = signature.len();
+    assert!(
+        // prevent API misuse
+        sign_size == spdmlib::protocol::ECDSA_ECC_NIST_P256_KEY_SIZE
+            || sign_size == spdmlib::protocol::ECDSA_ECC_NIST_P384_KEY_SIZE
+    );
     let half_size = sign_size / 2;
 
     let mut r_index = half_size;


### PR DESCRIPTION
Currently, function ecc_signature_bin_to_der use the short definite length DER encoding, the length of data in the V field must be <= 127 octets. While for the current set of supported curves, this should always be the case, this may change in the future. To prevent the API misuse, this PR add assert check for the signature length.