### PR TITLE
add sync/async mode check for features input.

### DIFF
--- a/test/spdm-emu/src/lib.rs
+++ b/test/spdm-emu/src/lib.rs
@@ -4,6 +4,12 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(all(
+    feature = "is_sync",
+    any(feature = "async-executor", feature = "async-tokio")
+))]
+compile_error!("Only support either sync mode or async mode, not both at the same time!");
+
 #[cfg(not(feature = "is_sync"))]
 pub mod async_runtime;
 pub mod crypto;

--- a/test/spdm-responder-emu/Cargo.toml
+++ b/test/spdm-responder-emu/Cargo.toml
@@ -26,7 +26,7 @@ td-benchmark = { git = "https://github.com/confidential-containers/td-shim.git",
 
 [features]
 default = ["spdm-emu/default", "async-executor", "test_stack_size"]
-mut-auth = ["spdm-emu/mut-auth", "async-executor"]
+mut-auth = ["spdm-emu/mut-auth"]
 mandatory-mut-auth = ["mut-auth", "spdm-emu/mandatory-mut-auth"]
 spdm-ring = ["spdm-emu/spdm-ring"]
 spdm-mbedtls = ["spdm-emu/spdm-mbedtls"]


### PR DESCRIPTION
currently, if user choose async-executor and is_sync, or async-tokio and is_sync as features input, emu
will not report error.